### PR TITLE
Split host and port in .env variables

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -244,9 +244,10 @@ LND_DATA=/umbrel-path-location/app-data/lightning/data/lnd/
 ```
 
 2. **Set LND gRPC Host**:  
-Update the `LND_GRPC_HOST` variable to your specific gRPC host and port in robosats.env. Typically this is done as below:
+Update the `LND_GRPC_HOST` and `LND_GRPC_PORT` variables to your specific gRPC host and port in robosats.env. Typically this is done as below:
 ```env
-LND_GRPC_HOST=10.21.21.9:10009
+LND_GRPC_HOST=10.21.21.9
+LND_GRPC_PORT=10009
 ```
 
 

--- a/compose/env-sample/clntn/robosats.env
+++ b/compose/env-sample/clntn/robosats.env
@@ -3,33 +3,23 @@ COORDINATOR_ALIAS="coordinator_NAME_CLN"
 # Lightning node vendor: CLN | LND
 LNVENDOR='CLN'
 
-# LND configuration (only needed if LNVENDOR='LND')
-# LND directory to read TLS cert and macaroon
-#LND_DIR='/lnd/'
-#MACAROON_PATH='data/chain/bitcoin/testnet/admin.macaroon'
-
-# If LND directory is not specified, cert and macaroon can be provided as base64 strings
-# base64 ~/.lnd/tls.cert | tr -d '\n'
-#LND_CERT_BASE64='LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNLVENDQWRDZ0F3SUJBZ0lRQ0VoeGpPZXY1bGQyVFNPTXhKalFvekFLQmdncWhrak9QUVFEQWpBNE1SOHcKSFFZRFZRUUtFeFpzYm1RZ1lYVjBiMmRsYm1WeVlYUmxaQ0JqWlhKME1SVXdFd1lEVlFRREV3d3dNakJtTVRnMQpZelkwTnpVd0hoY05Nakl3TWpBNE1UWXhOalV3V2hjTk1qTXdOREExTVRZeE5qVXdXakE0TVI4d0hRWURWUVFLCkV4WnNibVFnWVhWMGIyZGxibVZ5WVhSbFpDQmpaWEowTVJVd0V3WURWUVFERXd3d01qQm1NVGcxWXpZME56VXcKV1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVNJVWdkcVMrWFZKL3EzY0JZeWd6ZDc2endaanlmdQpLK3BzcWNYVkFyeGZjU2NXQ25jbXliNGRaMy9Lc3lLWlRaamlySDE3aEY0OGtIMlp5clRZSW9hZG80RzdNSUc0Ck1BNEdBMVVkRHdFQi93UUVBd0lDcERBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjREFUQVBCZ05WSFJNQkFmOEUKQlRBREFRSC9NQjBHQTFVZERnUVdCQlEwWUJjZXdsd1BqYTJPRXFyTGxzZnJscEswUFRCaEJnTlZIUkVFV2pCWQpnZ3d3TWpCbU1UZzFZelkwTnpXQ0NXeHZZMkZzYUc5emRJSUVkVzVwZUlJS2RXNXBlSEJoWTJ0bGRJSUhZblZtClkyOXVib2NFZndBQUFZY1FBQUFBQUFBQUFBQUFBQUFBQUFBQUFZY0V3S2dRQW9jRUFBQUFBREFLQmdncWhrak8KUFFRREFnTkhBREJFQWlBd0dMY05qNXVZSkVwanhYR05OUnNFSzAwWmlSUUh2Qm50NHp6M0htWHBiZ0lnSWtvUQo3cHFvNGdWNGhiczdrSmt1bnk2bkxlNVg0ZzgxYjJQOW52ZnZ2bkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K'
-# base64 ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon | tr -d '\n'
-#LND_MACAROON_BASE64='AgEDbG5kAvgBAwoQsyI+PK+fyb7F2UyTeZ4seRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgMt90uD6v4truTadWCjlppoeJ4hZrL1SBb09Y+4WOiI0='
-
 # CLN directory (only needed if LNVENDOR='CLN')
 CLN_DIR='/cln/testnet/'
-CLN_GRPC_HOST='localhost:9999'
-CLN_GRPC_HOLD_HOST='localhost:9998'
+CLN_GRPC_HOST='localhost'
+CLN_GRPC_PORT='9999'
+CLN_GRPC_HOLD_HOST='localhost'
+CLN_GRPC_HOLD_PORT='9998'
 
 # Bitcoin Core Daemon RPC, used to validate addresses
-BITCOIND_RPCURL = 'http://127.0.0.1:18332'
+# mainnet: 8332, testnet: 18332, signet: 38332, regtest: 18443
+BITCOIND_RPCHOST = '127.0.0.1'
+BITCOIND_RPCPORT = '18332'
 BITCOIND_RPCUSER = 'robosats_testnet_bitcoind'
 BITCOIND_RPCPASSWORD = 'robosats_testnet_bitcoind'
 
-# Auto unlock LND password. Only used in development docker-compose environment.
-# It will fail starting up the node without it. 
-# To disable auto unlock, comment out 'wallet-unlock-password-file=/tmp/pwd' from 'docker/lnd/lnd.conf'
-LND_GRPC_HOST='localhost:10009'
-
-REDIS_URL='redis://localhost:6379/1'
+REDIS_HOST="localhost"
+REDIS_PORT="6379"
+REDIS_DB_NUMBER="1"
 
 # Postgresql Database (These are fed from STACK-XX.env)
 # Deprecated
@@ -44,6 +34,9 @@ POSTGRES_PORT='5432'
 # Tor proxy for remote calls (e.g. fetching prices or sending Telegram messages)
 USE_TOR='True'
 TOR_PROXY='127.0.0.1:9050'
+
+LOG_TO_CONSOLE=False
+LOGGER_LEVEL="WARNING"
 
 # List of market price public APIs. If the currency is available in more than 1 API, will use median price.
 MARKET_PRICE_APIS = 'https://blockchain.info/ticker, https://api.yadio.io/exrates/BTC'

--- a/compose/env-sample/lndtn/robosats.env
+++ b/compose/env-sample/lndtn/robosats.env
@@ -12,24 +12,19 @@ MACAROON_PATH='data/chain/bitcoin/testnet/admin.macaroon'
 LND_CERT_BASE64='LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNLVENDQWRDZ0F3SUJBZ0lRQ0VoeGpPZXY1bGQyVFNPTXhKalFvekFLQmdncWhrak9QUVFEQWpBNE1SOHcKSFFZRFZRUUtFeFpzYm1RZ1lYVjBiMmRsYm1WeVlYUmxaQ0JqWlhKME1SVXdFd1lEVlFRREV3d3dNakJtTVRnMQpZelkwTnpVd0hoY05Nakl3TWpBNE1UWXhOalV3V2hjTk1qTXdOREExTVRZeE5qVXdXakE0TVI4d0hRWURWUVFLCkV4WnNibVFnWVhWMGIyZGxibVZ5WVhSbFpDQmpaWEowTVJVd0V3WURWUVFERXd3d01qQm1NVGcxWXpZME56VXcKV1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVNJVWdkcVMrWFZKL3EzY0JZeWd6ZDc2endaanlmdQpLK3BzcWNYVkFyeGZjU2NXQ25jbXliNGRaMy9Lc3lLWlRaamlySDE3aEY0OGtIMlp5clRZSW9hZG80RzdNSUc0Ck1BNEdBMVVkRHdFQi93UUVBd0lDcERBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjREFUQVBCZ05WSFJNQkFmOEUKQlRBREFRSC9NQjBHQTFVZERnUVdCQlEwWUJjZXdsd1BqYTJPRXFyTGxzZnJscEswUFRCaEJnTlZIUkVFV2pCWQpnZ3d3TWpCbU1UZzFZelkwTnpXQ0NXeHZZMkZzYUc5emRJSUVkVzVwZUlJS2RXNXBlSEJoWTJ0bGRJSUhZblZtClkyOXVib2NFZndBQUFZY1FBQUFBQUFBQUFBQUFBQUFBQUFBQUFZY0V3S2dRQW9jRUFBQUFBREFLQmdncWhrak8KUFFRREFnTkhBREJFQWlBd0dMY05qNXVZSkVwanhYR05OUnNFSzAwWmlSUUh2Qm50NHp6M0htWHBiZ0lnSWtvUQo3cHFvNGdWNGhiczdrSmt1bnk2bkxlNVg0ZzgxYjJQOW52ZnZ2bkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K'
 # base64 ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon | tr -d '\n'
 LND_MACAROON_BASE64='AgEDbG5kAvgBAwoQsyI+PK+fyb7F2UyTeZ4seRIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24SCGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFpbhIEcmVhZBIFd3JpdGUaFgoHb25jaGFpbhIEcmVhZBIFd3JpdGUaFAoFcGVlcnMSBHJlYWQSBXdyaXRlGhgKBnNpZ25lchIIZ2VuZXJhdGUSBHJlYWQAAAYgMt90uD6v4truTadWCjlppoeJ4hZrL1SBb09Y+4WOiI0='
-
-# CLN directory (only needed if LNVENDOR='CLN')
-CLN_DIR='/cln/testnet/'
-CLN_GRPC_HOST='localhost:9999'
-CLN_GRPC_HOLD_HOST='localhost:9998'
+LND_GRPC_HOST='localhost'
+LND_GRPC_PORT='10009'
 
 # Bitcoin Core Daemon RPC, used to validate addresses
-# For mainnet the URL port is 8332
-BITCOIND_RPCURL = 'http://127.0.0.1:18332'
+# mainnet: 8332, testnet: 18332, signet: 38332, regtest: 18443
+BITCOIND_RPCHOST = '127.0.0.1'
+BITCOIND_RPCPORT = '18332'
 BITCOIND_RPCUSER = 'robosats_testnet_bitcoind'
 BITCOIND_RPCPASSWORD = 'robosats_testnet_bitcoind'
 
-# Auto unlock LND password. Only used in development docker-compose environment.
-# It will fail starting up the node without it. 
-# To disable auto unlock, comment out 'wallet-unlock-password-file=/tmp/pwd' from 'docker/lnd/lnd.conf'
-LND_GRPC_HOST='localhost:10009'
-
-REDIS_URL='redis://localhost:6379/1'
+REDIS_HOST="localhost"
+REDIS_PORT="6379"
+REDIS_DB_NUMBER="1"
 
 # Postgresql Database (These are fed from STACK-XX.env)
 # Deprecated
@@ -44,6 +39,9 @@ POSTGRES_PORT='5432'
 # Tor proxy for remote calls (e.g. fetching prices or sending Telegram messages)
 USE_TOR='True'
 TOR_PROXY='127.0.0.1:9050'
+
+LOG_TO_CONSOLE=False
+LOGGER_LEVEL="WARNING"
 
 # List of market price public APIs. If the currency is available in more than 1 API, will use median price.
 MARKET_PRICE_APIS = 'https://blockchain.info/ticker, https://api.yadio.io/exrates/BTC'

--- a/k8s/base/robosats-configmap.yml
+++ b/k8s/base/robosats-configmap.yml
@@ -21,7 +21,8 @@ data:
   I2P_LONG: ''
   INVOICE_AND_ESCROW_DURATION: "30"
   LND_DIR: '/lnd/'
-  LND_GRPC_HOST: 'lnd:10009'
+  LND_GRPC_HOST: 'lnd'
+  LND_GRPC_PORT: '10009'
   LOCAL_ALIAS: '127.0.0.1'
   MACAROON_PATH: 'data/chain/bitcoin/testnet/admin.macaroon'
   MAKER_FEE_SPLIT: "0.125"
@@ -51,7 +52,9 @@ data:
   POSTGRES_HOST: 'postgres'
   POSTGRES_PORT: '5432'
   PROPORTIONAL_ROUTING_FEE_LIMIT: "0.001"
-  REDIS_URL: 'redis://redis:6379/1'
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  REDIS_DB_NUMBER: "1"
   RETRY_TIME: "1"
   REWARD_TIP: "100"
   REWARDS_TIMEOUT_SECONDS: "30"


### PR DESCRIPTION
Related to https://github.com/RoboSats/robosats/pull/1363.
This PR also removes cln variables in `lndtn/robosats.env` and lnd variables in `clntn/robosats.env`.