### PR TITLE
feat(img): added blossom server configs

### DIFF
--- a/compose/blossom/config.yml
+++ b/compose/blossom/config.yml
@@ -1,0 +1,45 @@
+# Blossom Server Configuration for RoboSats
+
+publicDomain: ""
+
+databasePath: data/sqlite.db
+
+dashboard:
+  enabled: false
+  username: "admin"
+
+# Storage config
+storage:
+  backend: "local"
+  removeWhenNoOwners: false
+  local:
+    dir: "./data/blobs"
+
+  # keep encrypted images for 30 days
+  rules:
+    - type: "application/octet-stream" # no recognizable type
+      expiration: "30 days"
+    - type: "*"
+      expiration: "30 days"
+
+# (BUD-02)
+upload:
+  enabled: true
+  requireAuth: true # BUD-01/02 Nostr auth
+  requirePubkeyInRule: false
+
+# No need for media optimization
+media:
+  enabled: false
+  requireAuth: true
+  requirePubkeyInRule: false
+
+# (BUD-04) - disabled for privacy 
+list:
+  requireAuth: true
+  allowListOthers: false
+
+# already behind Tor via service:tor
+tor:
+  enabled: false
+  proxy: ""

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -144,7 +144,7 @@ services:
     network_mode: service:tor
 
   blossom:
-    image: ghcr.io/hzrd149/blossom-server:master
+    image: ghcr.io/hzrd149/blossom-server:master@sha256:bafb705a42431ad55d2d7c23e3cd8ce61f735b8d1096f134b31b5b166f7ffa28
     container_name: blossom${SUFFIX}
     restart: always
     environment:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       - redis
     network_mode: service:tor
 
-  celery-beat:                                 
+  celery-beat:
     image: recksato/robosats:${ROBOSATS_TAG:-v0.6.0-alpha@sha256:8cc975ff5942a3fb2a09827b8eaafebea1c851eb3ecf9be1aaac1f238cfa9fc1}
     container_name: beat${SUFFIX}
     restart: always
@@ -141,6 +141,17 @@ services:
     command: celery -A robosats beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
     depends_on:
       - redis
+    network_mode: service:tor
+
+  blossom:
+    image: ghcr.io/hzrd149/blossom-server:master
+    container_name: blossom${SUFFIX}
+    restart: always
+    environment:
+      PORT: 3006
+    volumes:
+      - ${BLOSSOM_CONFIG:?}:/app/config.yml:ro
+      - ${BLOSSOM_DATA:?}:/app/data
     network_mode: service:tor
 
   relay:
@@ -173,6 +184,6 @@ services:
       - ${BU_DIR1}:/backup1:rw
       - ${BU_DIR2}:/backup2:rw
       - ${BU_DIR3}:/backup3:rw
-      
+
 volumes:
   redisdata:

--- a/compose/env-sample/lndmn/.env
+++ b/compose/env-sample/lndmn/.env
@@ -1,0 +1,4 @@
+
+# Blossom server
+BLOSSOM_CONFIG=./blossom/config.yml
+BLOSSOM_DATA=./blossom_data_mn

--- a/compose/env-sample/lndtn/compose.env
+++ b/compose/env-sample/lndtn/compose.env
@@ -75,3 +75,7 @@ NODE_ALIAS='🤖RoboSats⚡(Testnet)'
 NODE_COLOR='#4126a7'
 
 LND_AUTOUNLOCK_PWD='./env-sample/lndtn/lnd_autounlock_pwd'
+
+# Blossom server
+BLOSSOM_CONFIG=./blossom/config.yml
+BLOSSOM_DATA=/custom_path/testnet/blossom_data

--- a/compose/nginx/mn.conf.d/local.conf
+++ b/compose/nginx/mn.conf.d/local.conf
@@ -92,6 +92,15 @@ server {
         proxy_set_header Host $host;
     }
 
+    location /blossom/ {
+        proxy_pass http://127.0.0.1:3006/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 10M;
+    }
+
     location = /favicon.ico { access_log off; log_not_found off; }
 
 }

--- a/compose/nginx/tn.conf.d/local.conf
+++ b/compose/nginx/tn.conf.d/local.conf
@@ -83,6 +83,15 @@ server {
         proxy_set_header Host $host;
     }
 
+    location /blossom/ {
+        proxy_pass http://127.0.0.1:3006/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 10M;
+    }
+
     location = /favicon.ico { access_log off; log_not_found off; }
 
 }


### PR DESCRIPTION
Related to https://github.com/RoboSats/robosats/issues/1206

This is the infrastructure piece for the encrypted image uploads.
It adds the **Blossom Server** to the coordinator stack, configured specifically for our privacy needs.

### Changes

- Added `blossom` service to the docker-compose stack.
- Configured Nginx to proxy `/blossom/` to the new service.
- Added `compose/blossom/config.yml` with **BUD-01/02 (Kind 24242)** authentication enabled.

### Configuration Details

- **Auth Required:** Uploads are strict—only authenticated robots can upload.
- **Privacy:** Listing files is disabled to prevent snooping.
- **Expiration:** Blobs expire after 30 days to keep storage clean.

This should be plug-and-play for any coordinator! 
Let me know your thoughts on this with main repo PR.