### PR TITLE
Onion Service DoS Mitigation

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -157,6 +157,17 @@ Restart the containers using the following command:
 Delete <None> images
 `docker rmi $(docker images -f 'dangling=true' -q)`
 
+## DoS protection for Onion services
+
+The repo ships layered Denial-of-Service defences for every onion service:
+Tor intro-point rate limiting (Proposal 305), Proof-of-Work client puzzles
+(auto-tuned by Tor ≥ 0.4.8.1), stream limits per rendezvous circuit, and
+per-circuit nginx rate limiting via the HAProxy PROXY protocol.
+
+See **[compose/dos-mitigation.md](dos-mitigation.md)** for a full explanation
+of each layer, monitoring with `MetricsPort`, the tuning cheat-sheet, and how
+to kill abusive circuits at runtime.
+
 ## Add Onion services
 
 At the moment the RoboSats image does not use TorControl of the Tor container to automatically generate the Onion hidden service. It simply exposes the port (18000 in the `/compose/env-sample` testnet orchestration) and exposes a hidden service defined  `/env/{namespace}/torrc`.

--- a/compose/dos-mitigation.md
+++ b/compose/dos-mitigation.md
@@ -122,28 +122,57 @@ All vhosts set:
 
 ## Monitoring PoW metrics
 
-Enable `MetricsPort` in torrc (already in the sample configs):
+`MetricsPort` exposes a plain **Prometheus text format** HTTP endpoint bound
+to `127.0.0.1:9035` inside the `tor` container.
 
-```
-MetricsPort 127.0.0.1:9035
-MetricsPortPolicy accept 127.0.0.1
-```
+### How to reach it
 
-Read metrics:
+All containers in the stack share the `tor` network namespace
+(`network_mode: service:tor`), so the metrics port is reachable from the
+**host machine** as well as from any container in the stack.
+
 ```sh
+# From the host (or any container in the stack):
 curl -s http://127.0.0.1:9035/metrics | grep -E "tor_hs_pow|tor_hs_rdv"
 ```
 
-Key gauges:
+Alternatively, exec into the tor container directly:
+```sh
+# Compose alias (testnet example):
+docker exec -it tor-lndtn wget -qO- http://127.0.0.1:9035/metrics | grep tor_hs_pow
+```
+
+### What the output looks like
+
+```
+# HELP tor_hs_pow_suggested_effort Suggested effort for requests with a proof of work client puzzle
+# TYPE tor_hs_pow_suggested_effort gauge
+tor_hs_pow_suggested_effort 0
+# HELP tor_hs_rdv_pow_pqueue_count Number of requests waiting in the proof of work priority queue
+# TYPE tor_hs_rdv_pow_pqueue_count gauge
+tor_hs_rdv_pow_pqueue_count 0
+```
+
+When idle (no attack), both values are **0**.  Under a DoS attack:
+- `tor_hs_pow_suggested_effort` climbs from 0 up toward 10000 — this is the
+  CPU puzzle difficulty published in your service descriptor.  Clients with
+  recent Tor Browser automatically solve it; older clients or bots that skip
+  it get deprioritised.
+- `tor_hs_rdv_pow_pqueue_count` > 0 means rendezvous requests are queued.
+  If this number is large and growing, lower `HiddenServicePoWQueueRate`.
+
+### Key gauges
 
 | Metric | Meaning |
 |--------|---------|
-| `tor_hs_pow_suggested_effort` | Current puzzle effort suggested to clients (0 = idle) |
+| `tor_hs_pow_suggested_effort` | Current puzzle difficulty (0 = idle, ~10000 = max) |
 | `tor_hs_rdv_pow_pqueue_count` | Rendezvous requests queued waiting for dispatch |
+| `tor_hs_intro_rejected_intro_req_count` | Intro requests rejected at intro points (Layer 1 firing) |
+| `tor_hs_intro_established_count` | Number of currently established intro circuits |
 
-If `tor_hs_pow_suggested_effort` is climbing, the service is under attack and
-PoW is actively filtering.  If `tor_hs_rdv_pow_pqueue_count` is growing, lower
-`HiddenServicePoWQueueRate` to increase effort faster.
+If `tor_hs_pow_suggested_effort` is climbing, PoW is actively filtering.
+If `tor_hs_rdv_pow_pqueue_count` is growing, lower `HiddenServicePoWQueueRate`
+to raise puzzle effort faster and drain the queue more slowly.
 
 ---
 

--- a/compose/dos-mitigation.md
+++ b/compose/dos-mitigation.md
@@ -1,0 +1,230 @@
+# RoboSats Coordinator — Onion Service DoS Mitigation Guide
+
+This document describes the layered DoS defences configured in this repo and
+explains how to operate them during an attack.
+
+References:
+- https://community.torproject.org/onion-services/advanced/dos/
+- https://onionservices.torproject.org/technology/security/pow/
+
+---
+
+## Defence layers (applied in order)
+
+```
+Internet ──► Tor intro points ──► Tor rendezvous ──► nginx (port 81) ──► Gunicorn/Daphne
+              [Layer 1]            [Layer 2]          [Layer 3]            [Layer 4]
+```
+
+### Layer 1 — Intro-point rate limiting (torrc)
+
+Limits how many introduction requests reach *your machine* per second.
+Applied at the Tor relay level so attackers pay bandwidth for each attempt.
+
+```
+HiddenServiceEnableIntroDoSDefense      1
+HiddenServiceEnableIntroDoSRatePerSec   25   # sustained: 25 new clients/s
+HiddenServiceEnableIntroDoSBurstPerSec  200  # burst: up to 200 within 1 s
+```
+
+Under light attack: tighten these values (e.g., rate=10, burst=50).
+Under heavy attack: go as low as rate=2, burst=10.
+
+### Layer 2 — Proof-of-Work rendezvous defense (torrc)
+
+Clients must solve a CPU puzzle (Equi-X, LGPL) before a rendezvous circuit
+is established.  Effort is **auto-tuned** by Tor — zero when idle, increases
+under load — so legitimate users are unaffected until the service is stressed.
+
+```
+HiddenServicePoWDefensesEnabled 1
+HiddenServicePoWQueueRate   250  # rendezvous requests dispatched/s
+HiddenServicePoWQueueBurst  2500 # max burst from the priority queue
+```
+
+Lower `PoWQueueRate`/`PoWQueueBurst` → higher puzzle effort imposed on
+clients (attackers pay more CPU; legitimate Tor Browser users get slightly
+slower connections).
+
+**Requirement:** tor ≥ 0.4.8.1 compiled with `--enable-gpl`.
+Verify with:
+```sh
+tor --list-modules          # must show:  pow: yes
+tor --version               # must mention: General Public License
+```
+
+The `compose/tor/Dockerfile` asserts both at build time and fails the build if
+PoW is not available.
+
+### Layer 3 — Stream limits + Circuit-ID export (torrc → nginx)
+
+```
+HiddenServiceMaxStreams           200   # max simultaneous streams per circuit
+HiddenServiceMaxStreamsCloseCircuit 1   # tear down offending circuits
+HiddenServiceExportCircuitID haproxy   # prepend PROXY-protocol header on port 81
+```
+
+`HiddenServiceExportCircuitID haproxy` makes Tor write a HAProxy PROXY
+protocol header before each connection:
+
+```
+PROXY TCP6 fc00:dead:beef:4dad::0000:00AB ::1 65535 42
+```
+
+The last 32 bits of the first IPv6 address encode the **global circuit ID**.
+Nginx reads this via `$proxy_protocol_addr` on port 81 and uses it as the
+key for `limit_req` / `limit_conn` zones — giving true *per-circuit* rate
+limiting instead of the useless `127.0.0.1` bucket.
+
+**Port topology**
+
+| Port | Listener | Traffic source |
+|------|----------|----------------|
+| 80   | clearnet vhost | public internet |
+| 81   | onion vhost (`proxy_protocol`) | Tor process only (`127.0.0.1`) |
+
+Nginx `torrc` entry:  `HiddenServicePort 80 127.0.0.1:81`
+
+### Layer 4 — nginx rate limiting + caching
+
+Defined in `compose/nginx/{tn,mn}.conf.d/local.conf`.
+
+#### Rate-limit zones (onion vhost, port 81)
+
+| Zone | Key | Rate | Used for |
+|------|-----|------|----------|
+| `onion_req` | circuit pseudo-IP | 10 r/s (tn) / 20 r/s (mn) | `/ `, cached API endpoints |
+| `onion_ws` | circuit pseudo-IP | 5 r/s (tn) / 10 r/s (mn) | `/ws/`, `/relay`, `/nostr`, `/blossom/` |
+| `onion_coord` | circuit pseudo-IP | 2 r/s | `/coordinator` |
+| `onion_conn` | circuit pseudo-IP | (connection count) | all locations |
+
+Excess requests get HTTP **429** (`limit_req_status 429`) so clients can
+back off gracefully.  Abusive circuits are also killed by Layer 3.
+
+#### Response caching (hot read endpoints)
+
+`/api/info`, `/api/limits`, `/api/ticks`, `/api/book` are cached for **5 s**
+with `proxy_cache_lock on`.  Under a flood only one upstream request fires per
+cache miss; all other circuits get the cached response instantly.  This is the
+single most effective measure against book/info floods.
+
+#### Connection hygiene
+
+All vhosts set:
+- `client_body_timeout 10s`
+- `client_header_timeout 10s`
+- `send_timeout 30s`
+- `reset_timedout_connection on`
+- `proxy_read_timeout 3600s` (WebSocket connections)
+- `return 444` for requests with an empty `User-Agent` header
+
+---
+
+## Monitoring PoW metrics
+
+Enable `MetricsPort` in torrc (already in the sample configs):
+
+```
+MetricsPort 127.0.0.1:9035
+MetricsPortPolicy accept 127.0.0.1
+```
+
+Read metrics:
+```sh
+curl -s http://127.0.0.1:9035/metrics | grep -E "tor_hs_pow|tor_hs_rdv"
+```
+
+Key gauges:
+
+| Metric | Meaning |
+|--------|---------|
+| `tor_hs_pow_suggested_effort` | Current puzzle effort suggested to clients (0 = idle) |
+| `tor_hs_rdv_pow_pqueue_count` | Rendezvous requests queued waiting for dispatch |
+
+If `tor_hs_pow_suggested_effort` is climbing, the service is under attack and
+PoW is actively filtering.  If `tor_hs_rdv_pow_pqueue_count` is growing, lower
+`HiddenServicePoWQueueRate` to increase effort faster.
+
+---
+
+## Tuning cheat-sheet
+
+| Symptom | Action |
+|---------|--------|
+| `tor_hs_pow_suggested_effort` rising but queue not draining | Lower `HiddenServicePoWQueueRate` (e.g., 50) |
+| Introduction flood overwhelming the service | Lower `HiddenServiceEnableIntroDoSRatePerSec` (e.g., 10) and `...BurstPerSec` (e.g., 50) |
+| Specific circuits hammering nginx (HTTP 429 in logs) | Tighten `onion_req` / `onion_ws` zone rates |
+| Specific circuits survive rate limits (slow POST flood) | Lower `HiddenServiceMaxStreams` (e.g., 50) |
+| Attack is distributed across many circuits (botnet) | Increase `HiddenServicePoWQueueRate` difficulty or temporarily reduce `HiddenServicePoWQueueBurst` |
+
+---
+
+## Killing a specific abusive circuit via ControlPort
+
+`HiddenServiceExportCircuitID haproxy` encodes the circuit ID in nginx logs.
+Read it from the `$proxy_protocol_addr` IPv6 address:
+
+```
+# IPv6: fc00:dead:beef:4dad::AABB:CCDD
+# circuit_id = (0xAA << 24) | (0xBB << 16) | (0xCC << 8) | 0xDD
+
+python3 -c "
+addr = 'fc00:dead:beef:4dad::0000:00ab'
+words = addr.split('::')[1].split(':')
+hex_str = ''.join(w.zfill(4) for w in words)
+print('circuit_id =', int(hex_str, 16))
+"
+```
+
+Then kill it via the Tor control port:
+```sh
+# Inside the tor container:
+echo -e 'AUTHENTICATE\r\nCLOSECIRCUIT <circuit_id>\r\nQUIT' \
+  | nc 127.0.0.1 9051
+```
+
+---
+
+## Private admin onions — Client Authorization
+
+The admin panel, Thunderhub, LiT, and LNDg onion services do **not** use PoW
+(they are private; PoW would burden legitimate admins with puzzle-solving).
+Instead, restrict them with v3 client authorization:
+
+```
+# In torrc, per service:
+HiddenServiceDir /var/lib/tor/robotest-admin/
+HiddenServiceVersion 3
+HiddenServiceAuthorizeClient stealth <alice>,<bob>
+```
+
+See: https://community.torproject.org/onion-services/advanced/client-auth/
+
+---
+
+## Horizontal scaling (Onionbalance)
+
+If a single coordinator is overwhelmed despite all defences, Onionbalance
+distributes requests across multiple backend instances behind one onion address:
+
+```
+onion address (published)
+       │
+  Onionbalance
+   ┌───┴────┐
+   │        │
+backend1  backend2
+```
+
+See: https://onionservices.torproject.org/apps/base/onionbalance/
+
+---
+
+## What is NOT covered here
+
+- **Django/DRF throttling** — backend-level throttle classes live in the
+  `robosats` app repo (not this deploy repo).
+- **Captchas** — suitable for extreme attacks; requires OpenResty + Lua or an
+  external service.
+- **I2P** — the I2P stack (`compose/i2p/`) has its own DoS surface; consult
+  I2P documentation for equivalent mitigations.

--- a/compose/dos-mitigation.md
+++ b/compose/dos-mitigation.md
@@ -202,24 +202,6 @@ See: https://community.torproject.org/onion-services/advanced/client-auth/
 
 ---
 
-## Horizontal scaling (Onionbalance)
-
-If a single coordinator is overwhelmed despite all defences, Onionbalance
-distributes requests across multiple backend instances behind one onion address:
-
-```
-onion address (published)
-       │
-  Onionbalance
-   ┌───┴────┐
-   │        │
-backend1  backend2
-```
-
-See: https://onionservices.torproject.org/apps/base/onionbalance/
-
----
-
 ## What is NOT covered here
 
 - **Django/DRF throttling** — backend-level throttle classes live in the

--- a/compose/env-sample/clntn/torrc
+++ b/compose/env-sample/clntn/torrc
@@ -5,8 +5,46 @@ Log notice file /var/log/tor/notices.log
 DataDirectory /var/lib/tor
 DataDirectoryGroupReadable 1
 
-## Enable ControlPort
+## Enable ControlPort (required for HiddenServiceExportCircuitID)
 ControlPort 9051
 CookieAuthentication 1
 CookieAuthFileGroupReadable 1
 CookieAuthFile /var/lib/tor/control_auth_cookie
+
+## Expose Prometheus-style metrics for PoW monitoring.
+## Metrics are only reachable from localhost; use `curl http://127.0.0.1:9035/metrics`
+## to read tor_hs_pow_suggested_effort and tor_hs_rdv_pow_pqueue_count.
+MetricsPort 127.0.0.1:9035
+MetricsPortPolicy accept 127.0.0.1
+
+# ---------------------------------------------------------------------------
+# Robosats CLN Testnet Onion Service  (public — all DoS defenses enabled)
+# ---------------------------------------------------------------------------
+# NOTE: HiddenServicePort points to port 81 instead of 80.
+#       Nginx listens on 81 with PROXY protocol enabled so that each
+#       Tor circuit gets a unique pseudo-IP for per-circuit rate limiting.
+#       The clearnet vhost stays on port 80 and is unaffected.
+# (Replace with your actual HiddenServiceDir path once configured)
+HiddenServiceDir /var/lib/tor/robocln/
+HiddenServiceVersion 3
+HiddenServicePort 80 127.0.0.1:81
+
+## 1. Intro-point DoS defense (Proposal 305)
+HiddenServiceEnableIntroDoSDefense 1
+HiddenServiceEnableIntroDoSRatePerSec 25
+HiddenServiceEnableIntroDoSBurstPerSec 200
+
+## 2. Proof-of-Work rendezvous defense (requires tor >= 0.4.8.1 + --enable-gpl)
+HiddenServicePoWDefensesEnabled 1
+HiddenServicePoWQueueRate 250
+HiddenServicePoWQueueBurst 2500
+
+## 3. Stream (connection) limits per rendezvous circuit
+HiddenServiceMaxStreams 200
+HiddenServiceMaxStreamsCloseCircuit 1
+
+## 4. Circuit-ID export for nginx per-circuit rate limiting
+HiddenServiceExportCircuitID haproxy
+
+## 5. Number of introduction points
+HiddenServiceNumIntroductionPoints 3

--- a/compose/env-sample/lndtn/torrc
+++ b/compose/env-sample/lndtn/torrc
@@ -5,30 +5,109 @@ Log notice file /var/log/tor/notices.log
 DataDirectory /var/lib/tor
 DataDirectoryGroupReadable 1
 
-## Enable ControlPort
+## Enable ControlPort (required for HiddenServiceExportCircuitID)
 ControlPort 9051
 CookieAuthentication 1
 CookieAuthFileGroupReadable 1
 CookieAuthFile /var/lib/tor/control_auth_cookie
 
-# Robosats LND Testnet Onion Service
+## Expose Prometheus-style metrics for PoW monitoring.
+## Metrics are only reachable from localhost; use `curl http://127.0.0.1:9035/metrics`
+## to read tor_hs_pow_suggested_effort and tor_hs_rdv_pow_pqueue_count.
+MetricsPort 127.0.0.1:9035
+MetricsPortPolicy accept 127.0.0.1
+
+# ---------------------------------------------------------------------------
+# Robosats LND Testnet Onion Service  (public — all DoS defenses enabled)
+# ---------------------------------------------------------------------------
+# NOTE: HiddenServicePort points to port 81 instead of 80.
+#       Nginx listens on 81 with PROXY protocol enabled so that each
+#       Tor circuit gets a unique pseudo-IP for per-circuit rate limiting.
+#       The clearnet vhost stays on port 80 and is unaffected.
 HiddenServiceDir /var/lib/tor/robotest/
 HiddenServiceVersion 3
-HiddenServicePort 80 127.0.0.1:80
+HiddenServicePort 80 127.0.0.1:81
 
-# Robosats Admin Testnet Onion Service
+## 1. Intro-point DoS defense (Proposal 305)
+##    Limits introduction requests at the relay level before they ever
+##    reach your machine.  Defaults are 25 r/s rate, 200 burst — sensible
+##    starting point; lower if under heavy attack.
+HiddenServiceEnableIntroDoSDefense 1
+HiddenServiceEnableIntroDoSRatePerSec 25
+HiddenServiceEnableIntroDoSBurstPerSec 200
+
+## 2. Proof-of-Work rendezvous defense (requires tor >= 0.4.8.1 + --enable-gpl)
+##    Clients must solve a CPU puzzle before a rendezvous circuit is opened.
+##    Effort is auto-tuned (0 when idle, climbs under attack).
+##    Lower QueueRate/QueueBurst → higher puzzle effort for clients.
+HiddenServicePoWDefensesEnabled 1
+HiddenServicePoWQueueRate 250
+HiddenServicePoWQueueBurst 2500
+
+## 3. Stream (connection) limits per rendezvous circuit
+##    Prevents one circuit from monopolising the service.
+##    200 simultaneous streams covers any legitimate browser session;
+##    setting CloseCircuit=1 actively tears down abusive circuits.
+HiddenServiceMaxStreams 200
+HiddenServiceMaxStreamsCloseCircuit 1
+
+## 4. Circuit-ID export for nginx per-circuit rate limiting
+##    Tor prepends a HAProxy PROXY-protocol header encoding the global
+##    circuit ID.  Nginx reads this on port 81 and uses it as the key
+##    for limit_req / limit_conn zones — so attackers can't hide behind
+##    shared 127.0.0.1 loopback address.
+HiddenServiceExportCircuitID haproxy
+
+## 5. Number of introduction points (default 3, max 20).
+##    More IPs spread the attack surface; 3 is fine for most coordinators.
+HiddenServiceNumIntroductionPoints 3
+
+# ---------------------------------------------------------------------------
+# Robosats Admin Testnet Onion Service  (private panel)
+# ---------------------------------------------------------------------------
+# No PoW here — admin panel is low-traffic and circuit-ID is less useful.
+# Use HiddenServiceAuthorizeClient (v3 client auth) to restrict access instead.
 HiddenServiceDir /var/lib/tor/robotest-admin/
 HiddenServiceVersion 3
 HiddenServicePort 80 127.0.0.1:80
+HiddenServiceEnableIntroDoSDefense 1
+HiddenServiceEnableIntroDoSRatePerSec 5
+HiddenServiceEnableIntroDoSBurstPerSec 20
+HiddenServiceMaxStreams 10
+HiddenServiceMaxStreamsCloseCircuit 1
 
+# ---------------------------------------------------------------------------
+# Thunderhub  (private — admin LN wallet UI)
+# ---------------------------------------------------------------------------
 HiddenServiceDir /var/lib/tor/robotest-thunderhub/
 HiddenServiceVersion 3
 HiddenServicePort 80 127.0.0.1:3000
+HiddenServiceEnableIntroDoSDefense 1
+HiddenServiceEnableIntroDoSRatePerSec 5
+HiddenServiceEnableIntroDoSBurstPerSec 20
+HiddenServiceMaxStreams 10
+HiddenServiceMaxStreamsCloseCircuit 1
 
+# ---------------------------------------------------------------------------
+# Lightning Terminal (LiT)  (private)
+# ---------------------------------------------------------------------------
 HiddenServiceDir /var/lib/tor/robotest-lit/
 HiddenServiceVersion 3
 HiddenServicePort 8443 127.0.0.1:8443
+HiddenServiceEnableIntroDoSDefense 1
+HiddenServiceEnableIntroDoSRatePerSec 5
+HiddenServiceEnableIntroDoSBurstPerSec 20
+HiddenServiceMaxStreams 10
+HiddenServiceMaxStreamsCloseCircuit 1
 
+# ---------------------------------------------------------------------------
+# LNDg  (private)
+# ---------------------------------------------------------------------------
 HiddenServiceDir /var/lib/tor/robotest-lndg/
 HiddenServiceVersion 3
 HiddenServicePort 80 127.0.0.1:8889
+HiddenServiceEnableIntroDoSDefense 1
+HiddenServiceEnableIntroDoSRatePerSec 5
+HiddenServiceEnableIntroDoSBurstPerSec 20
+HiddenServiceMaxStreams 10
+HiddenServiceMaxStreamsCloseCircuit 1

--- a/compose/nginx/mn.conf.d/local.conf
+++ b/compose/nginx/mn.conf.d/local.conf
@@ -1,79 +1,123 @@
-limit_req_zone $binary_remote_addr zone=tenpersec:10m rate=100r/s;
+# =============================================================================
+#  RoboSats Mainnet coordinator — nginx configuration
+#  DoS hardening: per-circuit rate limiting via PROXY protocol (port 81)
+#                 clearnet rate limiting by IP (port 80)
+#                 response caching for hot public read endpoints
+# =============================================================================
 
-# first we declare our upstream server, which is our Gunicorn application
+# ---------------------------------------------------------------------------
+# Upstream application servers
+# ---------------------------------------------------------------------------
 upstream robosats_gunicorn_rest {
-    # docker will automatically resolve this to the correct address
-    # because we use the same name as the service: "robosats"
     server localhost:8000;
-    
 }
 
 upstream robosats_daphne_websocket {
-    # docker will automatically resolve this to the correct address
-    # because we use the same name as the service: "robosats"
     server localhost:9000;
 }
 
+# ---------------------------------------------------------------------------
+# Rate-limit zones
+#
+# IMPORTANT: all Tor onion traffic arrives at nginx from 127.0.0.1, so the
+# old `$binary_remote_addr` zone was useless — every circuit shared a single
+# bucket.  With HiddenServiceExportCircuitID haproxy, Tor prepends a PROXY
+# protocol header that encodes a unique circuit pseudo-IP.  We read that IP
+# via $proxy_protocol_addr on the port-81 vhost and use it as the zone key,
+# giving true per-circuit limiting.
+# ---------------------------------------------------------------------------
+
+# Clearnet (port 80) — keyed on real client IP
+limit_req_zone  $binary_remote_addr zone=cn_req:10m   rate=100r/s;
+limit_conn_zone $binary_remote_addr zone=cn_conn:10m;
+
+# Onion (port 81) — keyed on Tor circuit pseudo-IP from PROXY protocol
+limit_req_zone  $proxy_protocol_addr zone=onion_req:10m  rate=20r/s;
+limit_conn_zone $proxy_protocol_addr zone=onion_conn:10m;
+
+# Stricter zone for websocket upgrades (lower burst, faster circuit kill)
+limit_req_zone  $proxy_protocol_addr zone=onion_ws:10m   rate=10r/s;
+
+# Coordinator-only endpoints: very tight
+limit_req_zone  $proxy_protocol_addr zone=onion_coord:10m rate=2r/s;
+
+# ---------------------------------------------------------------------------
+# Onion address allowlist for /coordinator endpoint
+# ---------------------------------------------------------------------------
 map $host $allowed_onion {
     default 0;
-    "~*your-robotest-admin-onion-address\.onion" 1;  # Allows access for your coordinator onion address
+    "~*your-robotest-admin-onion-address\.onion" 1;  # Replace with your coordinator onion address
 }
 
-# now we declare our main server
+# ---------------------------------------------------------------------------
+# Proxy cache for hot public read-only endpoints
+# Keys zone 10 MB; max cached size 512 MB; files inactive after 30 s
+# ---------------------------------------------------------------------------
+proxy_cache_path /tmp/nginx_cache_mn
+    levels=1:2
+    keys_zone=robosats_mn:10m
+    max_size=512m
+    inactive=30s
+    use_temp_path=off;
+
+# =============================================================================
+#  Clearnet vhost (port 80) — HTTP, keyed on real client IP
+# =============================================================================
 server {
 
     listen 80;
     server_name robosats.com;
     large_client_header_buffers 4 64k;
 
+    # Connection hygiene
+    client_body_timeout    10s;
+    client_header_timeout  10s;
+    send_timeout           30s;
+    reset_timedout_connection on;
+    keepalive_timeout      30s;
+
     location /static {
         alias /usr/src/static;
     }
-    
+
     # Tor to web providers (identification files)
     location /.well-known {
         alias /usr/src/.well-known;
     }
 
     location / {
-        # requests are passed to Gunicorn
         proxy_pass http://robosats_gunicorn_rest;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
-        # Replace with the onion hidden service of your coordinator
         add_header Onion-Location http://satstraoq35jffvkgpfoqld32nzw2siuvowanruindbfojowpwsjdgad.onion$request_uri;
-        limit_req zone=tenpersec burst=10;
+        limit_req  zone=cn_req  burst=20 nodelay;
+        limit_conn cn_conn 20;
+        limit_req_status 429;
     }
 
     location /coordinator {
-        # Denies any access by default
         set $allow_access 0;
-
-        if ($allowed_onion = 1) {
-            set $allow_access 1; # Allows access for your coordinator onion address
-        }
-
-        if ($allow_access = 0){
-            return 403; # Access is forbidden if none of the above conditions are met.
-        }
+        if ($allowed_onion = 1) { set $allow_access 1; }
+        if ($allow_access = 0)  { return 403; }
 
         proxy_pass http://robosats_gunicorn_rest;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
-        # Replace with the onion hidden service of your coordinator
         add_header Onion-Location https://satstraoq35jffvkgpfoqld32nzw2siuvowanruindbfojowpwsjdgad.onion$request_uri;
     }
 
     location /ws/ {
-	# websockets are passed to Daphne
         proxy_pass http://robosats_daphne_websocket;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
-        limit_req zone=tenpersec burst=10;
+        proxy_read_timeout 3600s;
+        limit_req  zone=cn_req  burst=20 nodelay;
+        limit_conn cn_conn 10;
+        limit_req_status 429;
     }
 
     location /nostr {
@@ -82,6 +126,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
     }
 
     location /relay {
@@ -90,6 +135,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
     }
 
     location /blossom/ {
@@ -100,20 +146,166 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 10M;
 
-        # blossom-server always answers with "Access-Control-Allow-Origin: *"
-        add_header Access-Control-Allow-Origin "*" always;
+        limit_req  zone=cn_req  burst=5 nodelay;
+        limit_conn cn_conn 4;
+        limit_req_status 429;
+
+        add_header Access-Control-Allow-Origin  "*" always;
         add_header Access-Control-Allow-Methods "GET, HEAD, PUT, DELETE, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Authorization, Content-Type, *" always;
         add_header Access-Control-Max-Age 86400 always;
 
-        # Short-circuit CORS preflight requests so they don't need to reach
-        # the upstream Blossom server at all.
-        if ($request_method = OPTIONS) {
-            return 204;
-        }
+        if ($request_method = OPTIONS) { return 204; }
     }
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+}
+
+# =============================================================================
+#  Onion vhost (port 81) — PROXY protocol, keyed on Tor circuit pseudo-IP
+#
+#  Requirements:
+#    torrc:  HiddenServicePort 80 127.0.0.1:81
+#            HiddenServiceExportCircuitID haproxy
+#  This vhost must only be reachable from localhost (Tor process).
+# =============================================================================
+server {
+
+    listen 127.0.0.1:81 proxy_protocol;
+    server_name _;
+    large_client_header_buffers 4 64k;
+
+    # Trust the PROXY protocol address for real_ip and logging
+    set_real_ip_from 127.0.0.1;
+    real_ip_header   proxy_protocol;
+
+    # Connection hygiene
+    client_body_timeout    10s;
+    client_header_timeout  10s;
+    send_timeout           30s;
+    reset_timedout_connection on;
+    keepalive_timeout      30s;
+
+    # Reject requests with empty User-Agent (most attack scripts omit it)
+    if ($http_user_agent = "") { return 444; }
+
+    location /static {
+        alias /usr/src/static;
+    }
+
+    location /.well-known {
+        alias /usr/src/.well-known;
+    }
+
+    # ------------------------------------------------------------------
+    # Hot public read endpoints — served from cache to absorb floods
+    # ------------------------------------------------------------------
+    location ~* ^/(api/info|api/limits|api/ticks|api/book) {
+        proxy_pass http://robosats_gunicorn_rest;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+
+        proxy_cache            robosats_mn;
+        proxy_cache_valid      200 5s;
+        proxy_cache_lock       on;
+        proxy_cache_use_stale  updating error timeout;
+        proxy_cache_key        "$uri$is_args$args";
+        add_header X-Cache-Status $upstream_cache_status;
+
+        add_header Onion-Location http://satstraoq35jffvkgpfoqld32nzw2siuvowanruindbfojowpwsjdgad.onion$request_uri;
+
+        limit_req  zone=onion_req  burst=40 nodelay;
+        limit_conn onion_conn 16;
+        limit_req_status 429;
+    }
+
+    location / {
+        proxy_pass http://robosats_gunicorn_rest;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+        add_header Onion-Location http://satstraoq35jffvkgpfoqld32nzw2siuvowanruindbfojowpwsjdgad.onion$request_uri;
+
+        limit_req  zone=onion_req  burst=40 nodelay;
+        limit_conn onion_conn 16;
+        limit_req_status 429;
+    }
+
+    location /coordinator {
+        set $allow_access 0;
+        if ($allowed_onion = 1) { set $allow_access 1; }
+        if ($allow_access = 0)  { return 403; }
+
+        proxy_pass http://robosats_gunicorn_rest;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+        add_header Onion-Location https://satstraoq35jffvkgpfoqld32nzw2siuvowanruindbfojowpwsjdgad.onion$request_uri;
+
+        limit_req  zone=onion_coord burst=5 nodelay;
+        limit_conn onion_conn 4;
+        limit_req_status 429;
+    }
+
+    location /ws/ {
+        proxy_pass http://robosats_daphne_websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+
+        limit_req  zone=onion_ws   burst=10 nodelay;
+        limit_conn onion_conn 8;
+        limit_req_status 429;
+    }
+
+    location /nostr {
+        proxy_pass http://127.0.0.1:7777;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+
+        limit_req  zone=onion_ws   burst=10 nodelay;
+        limit_conn onion_conn 8;
+        limit_req_status 429;
+    }
+
+    location /relay {
+        proxy_pass http://127.0.0.1:7778;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+
+        limit_req  zone=onion_ws   burst=10 nodelay;
+        limit_conn onion_conn 8;
+        limit_req_status 429;
+    }
+
+    location /blossom/ {
+        proxy_pass http://127.0.0.1:3006/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $proxy_protocol_addr;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 10M;
+
+        # Tighter limits for uploads
+        limit_req  zone=onion_ws   burst=3 nodelay;
+        limit_conn onion_conn 2;
+        limit_req_status 429;
+
+        add_header Access-Control-Allow-Origin  "*" always;
+        add_header Access-Control-Allow-Methods "GET, HEAD, PUT, DELETE, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, *" always;
+        add_header Access-Control-Max-Age 86400 always;
+
+        if ($request_method = OPTIONS) { return 204; }
+    }
 
     location = /favicon.ico { access_log off; log_not_found off; }
-
 }

--- a/compose/nginx/tn.conf.d/local.conf
+++ b/compose/nginx/tn.conf.d/local.conf
@@ -1,30 +1,84 @@
-limit_req_zone $binary_remote_addr zone=fivepersec:10m rate=5r/s;
+# =============================================================================
+#  RoboSats Testnet coordinator — nginx configuration
+#  DoS hardening: per-circuit rate limiting via PROXY protocol (port 81)
+#                 clearnet rate limiting by IP (port 80)
+#                 response caching for hot public read endpoints
+# =============================================================================
 
-# first we declare our upstream server, which is our Gunicorn application
+# ---------------------------------------------------------------------------
+# Upstream application servers
+# ---------------------------------------------------------------------------
 upstream robosats_gunicorn_rest {
-    # docker will automatically resolve this to the correct address
-    # because we use the same name as the service: "robosats"
     server localhost:8000;
-    
 }
 
 upstream robosats_daphne_websocket {
-    # docker will automatically resolve this to the correct address
-    # because we use the same name as the service: "robosats"
     server localhost:9000;
 }
 
+# ---------------------------------------------------------------------------
+# Rate-limit zones
+#
+# IMPORTANT: all Tor onion traffic arrives at nginx from 127.0.0.1, so the
+# old `$binary_remote_addr` zone was useless — every circuit shared a single
+# bucket.  With HiddenServiceExportCircuitID haproxy, Tor prepends a PROXY
+# protocol header that encodes a unique circuit pseudo-IP.  We read that IP
+# via $proxy_protocol_addr on the port-81 vhost and use it as the zone key,
+# giving true per-circuit limiting.
+# ---------------------------------------------------------------------------
+
+# Clearnet (port 80) — keyed on real client IP
+limit_req_zone  $binary_remote_addr zone=cn_req:10m   rate=5r/s;
+limit_conn_zone $binary_remote_addr zone=cn_conn:10m;
+
+# Onion (port 81) — keyed on Tor circuit pseudo-IP from PROXY protocol
+limit_req_zone  $proxy_protocol_addr zone=onion_req:10m  rate=10r/s;
+limit_conn_zone $proxy_protocol_addr zone=onion_conn:10m;
+
+# Stricter zone for websocket upgrades (lower burst, faster circuit kill)
+limit_req_zone  $proxy_protocol_addr zone=onion_ws:10m   rate=5r/s;
+
+# Coordinator-only endpoints: very tight (these are crawled by bots)
+limit_req_zone  $proxy_protocol_addr zone=onion_coord:10m rate=2r/s;
+
+# ---------------------------------------------------------------------------
+# Onion address allowlist for /coordinator endpoint
+# ---------------------------------------------------------------------------
 map $host $allowed_onion {
     default 0;
-    "~*testraliar7xkhos2gipv2k65obykofb4jqzl5l4danfryacifi4t7qd\.onion" 1;  # Allows access for your coordinator onion address
+    "~*testraliar7xkhos2gipv2k65obykofb4jqzl5l4danfryacifi4t7qd\.onion" 1;  # Replace with your coordinator onion address
 }
 
-# now we declare our main server
+# ---------------------------------------------------------------------------
+# Proxy cache for hot public read-only endpoints
+# Keys zone 10 MB; max cached size 512 MB; files inactive after 30 s
+# ---------------------------------------------------------------------------
+proxy_cache_path /tmp/nginx_cache_tn
+    levels=1:2
+    keys_zone=robosats_tn:10m
+    max_size=512m
+    inactive=30s
+    use_temp_path=off;
+
+# ---------------------------------------------------------------------------
+# Shared proxy / performance settings applied via include or duplication
+# ---------------------------------------------------------------------------
+
+# =============================================================================
+#  Clearnet vhost (port 80) — HTTP, keyed on real client IP
+# =============================================================================
 server {
 
     listen 80;
     server_name satstralia.com;
     large_client_header_buffers 4 64k;
+
+    # Connection hygiene
+    client_body_timeout    10s;
+    client_header_timeout  10s;
+    send_timeout           30s;
+    reset_timedout_connection on;
+    keepalive_timeout      30s;
 
     location /static {
         alias /usr/src/static;
@@ -35,44 +89,35 @@ server {
     }
 
     location / {
-        # requests are passed to Gunicorn
         proxy_pass http://robosats_gunicorn_rest;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
-        # Replace with the onion hidden service of your coordinator
         add_header Onion-Location https://testraliar7xkhos2gipv2k65obykofb4jqzl5l4danfryacifi4t7qd.onion$request_uri;
-        limit_req zone=fivepersec burst=10;
+        limit_req  zone=cn_req  burst=15 nodelay;
+        limit_conn cn_conn 10;
+        limit_req_status 429;
     }
 
     location /coordinator {
-        # Denies any access by default
         set $allow_access 0;
-
-        if ($allowed_onion = 1) {
-            set $allow_access 1; # Allows access for your coordinator onion address
-        }
-
-        if ($allow_access = 0){
-            return 403; # Access is forbidden if none of the above conditions are met.
-        }
+        if ($allowed_onion = 1) { set $allow_access 1; }
+        if ($allow_access = 0) { return 403; }
 
         proxy_pass http://robosats_gunicorn_rest;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
-        # Replace with the onion hidden service of your coordinator
         add_header Onion-Location https://testraliar7xkhos2gipv2k65obykofb4jqzl5l4danfryacifi4t7qd.onion$request_uri;
-
     }
 
     location /ws/ {
-	    # websockets are passed to Daphne
         proxy_pass http://robosats_daphne_websocket;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
     }
 
     location /relay {
@@ -81,6 +126,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
     }
 
     location /blossom/ {
@@ -91,19 +137,155 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 10M;
 
-        # blossom-server always answers with "Access-Control-Allow-Origin: *"
-        add_header Access-Control-Allow-Origin "*" always;
+        limit_req  zone=cn_req  burst=5 nodelay;
+        limit_conn cn_conn 4;
+        limit_req_status 429;
+
+        add_header Access-Control-Allow-Origin  "*" always;
         add_header Access-Control-Allow-Methods "GET, HEAD, PUT, DELETE, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Authorization, Content-Type, *" always;
         add_header Access-Control-Max-Age 86400 always;
 
-        # Short-circuit CORS preflight requests so they don't need to reach
-        # the upstream Blossom server at all.
-        if ($request_method = OPTIONS) {
-            return 204;
-        }
+        if ($request_method = OPTIONS) { return 204; }
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }
+}
 
+# =============================================================================
+#  Onion vhost (port 81) — PROXY protocol, keyed on Tor circuit pseudo-IP
+#
+#  Requirements:
+#    torrc:  HiddenServicePort 80 127.0.0.1:81
+#            HiddenServiceExportCircuitID haproxy
+#  This vhost must only be reachable from localhost (Tor process).
+# =============================================================================
+server {
+
+    listen 127.0.0.1:81 proxy_protocol;
+    server_name _;
+    large_client_header_buffers 4 64k;
+
+    # Trust the PROXY protocol address for real_ip and logging
+    set_real_ip_from 127.0.0.1;
+    real_ip_header   proxy_protocol;
+
+    # Connection hygiene
+    client_body_timeout    10s;
+    client_header_timeout  10s;
+    send_timeout           30s;
+    reset_timedout_connection on;
+    keepalive_timeout      30s;
+
+    # Reject requests with empty User-Agent (most attack scripts omit it)
+    if ($http_user_agent = "") { return 444; }
+
+    location /static {
+        alias /usr/src/static;
+    }
+
+    location /.well-known {
+        alias /usr/src/.well-known;
+    }
+
+    # ------------------------------------------------------------------
+    # Hot public read endpoints — served from cache to absorb floods
+    # Cache 5 s; serve stale while revalidating; lock so only one
+    # upstream request fires for each cache miss.
+    # ------------------------------------------------------------------
+    location ~* ^/(api/info|api/limits|api/ticks|api/book) {
+        proxy_pass http://robosats_gunicorn_rest;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+
+        proxy_cache            robosats_tn;
+        proxy_cache_valid      200 5s;
+        proxy_cache_lock       on;
+        proxy_cache_use_stale  updating error timeout;
+        proxy_cache_key        "$uri$is_args$args";
+        add_header X-Cache-Status $upstream_cache_status;
+
+        add_header Onion-Location https://testraliar7xkhos2gipv2k65obykofb4jqzl5l4danfryacifi4t7qd.onion$request_uri;
+
+        limit_req  zone=onion_req  burst=20 nodelay;
+        limit_conn onion_conn 8;
+        limit_req_status 429;
+    }
+
+    location / {
+        proxy_pass http://robosats_gunicorn_rest;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+        add_header Onion-Location https://testraliar7xkhos2gipv2k65obykofb4jqzl5l4danfryacifi4t7qd.onion$request_uri;
+
+        limit_req  zone=onion_req  burst=20 nodelay;
+        limit_conn onion_conn 8;
+        limit_req_status 429;
+    }
+
+    location /coordinator {
+        set $allow_access 0;
+        if ($allowed_onion = 1) { set $allow_access 1; }
+        if ($allow_access = 0)  { return 403; }
+
+        proxy_pass http://robosats_gunicorn_rest;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+        add_header Onion-Location https://testraliar7xkhos2gipv2k65obykofb4jqzl5l4danfryacifi4t7qd.onion$request_uri;
+
+        limit_req  zone=onion_coord burst=5 nodelay;
+        limit_conn onion_conn 4;
+        limit_req_status 429;
+    }
+
+    location /ws/ {
+        proxy_pass http://robosats_daphne_websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+
+        limit_req  zone=onion_ws   burst=5 nodelay;
+        limit_conn onion_conn 4;
+        limit_req_status 429;
+    }
+
+    location /relay {
+        proxy_pass http://127.0.0.1:7778;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+
+        limit_req  zone=onion_ws   burst=5 nodelay;
+        limit_conn onion_conn 4;
+        limit_req_status 429;
+    }
+
+    location /blossom/ {
+        proxy_pass http://127.0.0.1:3006/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $proxy_protocol_addr;
+        proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 10M;
+
+        # Tighter limits for uploads — uploads are expensive
+        limit_req  zone=onion_ws   burst=3 nodelay;
+        limit_conn onion_conn 2;
+        limit_req_status 429;
+
+        add_header Access-Control-Allow-Origin  "*" always;
+        add_header Access-Control-Allow-Methods "GET, HEAD, PUT, DELETE, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, *" always;
+        add_header Access-Control-Max-Age 86400 always;
+
+        if ($request_method = OPTIONS) { return 204; }
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
 }

--- a/compose/tor/Dockerfile
+++ b/compose/tor/Dockerfile
@@ -1,6 +1,11 @@
-FROM alpine:3
+FROM alpine:3.21
 
-RUN apk --no-cache --no-progress add tor=~0.4
+# Require tor >= 0.4.8.x compiled with --enable-gpl (needed for PoW Equi-X library)
+# Alpine 3.20+ ships tor 0.4.9.x built with --enable-gpl, so `pow: yes` and GPL are guaranteed.
+RUN apk --no-cache --no-progress add tor=~0.4 && \
+    # Hard-fail the build if PoW support is missing (requires --enable-gpl + pow module)
+    tor --list-modules | grep -q '^pow: yes' && \
+    tor --version | grep -q 'General Public License'
 
 EXPOSE 9001 9050
 

--- a/k8s/base/tor/configmap.yml
+++ b/k8s/base/tor/configmap.yml
@@ -10,8 +10,36 @@ data:
     # HashedControlPassword 16:B55F2A0995402608605FB7206DE0E474DF92EE2026A2FFBB1B8AC7A926 
     # CookieAuthentication 0
 
+    # ---------------------------------------------------------------------------
+    # Robosats Onion Service  (public — all DoS defenses enabled)
+    # ---------------------------------------------------------------------------
+    # NOTE: HiddenServicePort points to port 81 (PROXY-protocol nginx vhost).
     HiddenServiceDir /var/lib/tor/robosite/
-    HiddenServicePort 80 nginx:80
+    HiddenServicePort 80 nginx:81
+
+    # 1. Intro-point DoS defense (Proposal 305)
+    HiddenServiceEnableIntroDoSDefense 1
+    HiddenServiceEnableIntroDoSRatePerSec 25
+    HiddenServiceEnableIntroDoSBurstPerSec 200
+
+    # 2. Proof-of-Work rendezvous defense (requires tor >= 0.4.8.1 + --enable-gpl)
+    HiddenServicePoWDefensesEnabled 1
+    HiddenServicePoWQueueRate 250
+    HiddenServicePoWQueueBurst 2500
+
+    # 3. Stream limits per rendezvous circuit
+    HiddenServiceMaxStreams 200
+    HiddenServiceMaxStreamsCloseCircuit 1
+
+    # 4. Circuit-ID export for nginx per-circuit rate limiting
+    HiddenServiceExportCircuitID haproxy
+
+    # 5. Number of introduction points
+    HiddenServiceNumIntroductionPoints 3
+
+    # Prometheus metrics for PoW monitoring (scraped from localhost:9035/metrics)
+    MetricsPort 127.0.0.1:9035
+    MetricsPortPolicy accept 127.0.0.1
 
     # add:
     # CookieAuthFileGroupReadable 1 

--- a/web/torrc
+++ b/web/torrc
@@ -5,13 +5,45 @@ Log notice file /var/log/tor/notices.log
 DataDirectory /var/lib/tor
 DataDirectoryGroupReadable 1
 
-## Enable ControlPort
+## Enable ControlPort (required for HiddenServiceExportCircuitID)
 #ControlPort 9051
 #CookieAuthentication 1
 #CookieAuthFileGroupReadable 1
 #CookieAuthFile /var/lib/tor/control_auth_cookie
 
-# Robosats LND Testnet Onion Service
+## Expose Prometheus-style metrics for PoW monitoring.
+## Metrics are only reachable from localhost; use `curl http://127.0.0.1:9035/metrics`
+## to read tor_hs_pow_suggested_effort and tor_hs_rdv_pow_pqueue_count.
+#MetricsPort 127.0.0.1:9035
+#MetricsPortPolicy accept 127.0.0.1
+
+# ---------------------------------------------------------------------------
+# Robosats Web Client Onion Service  (public — all DoS defenses enabled)
+# ---------------------------------------------------------------------------
+# NOTE: HiddenServicePort points to port 81 instead of 80.
+#       Nginx listens on 81 with PROXY protocol enabled so that each
+#       Tor circuit gets a unique pseudo-IP for per-circuit rate limiting.
+#       The clearnet vhost stays on port 80 and is unaffected.
 HiddenServiceDir /var/lib/tor/roboweb/
 HiddenServiceVersion 3
-HiddenServicePort 80 127.0.0.1:80
+HiddenServicePort 80 127.0.0.1:81
+
+## 1. Intro-point DoS defense (Proposal 305)
+HiddenServiceEnableIntroDoSDefense 1
+HiddenServiceEnableIntroDoSRatePerSec 25
+HiddenServiceEnableIntroDoSBurstPerSec 200
+
+## 2. Proof-of-Work rendezvous defense (requires tor >= 0.4.8.1 + --enable-gpl)
+HiddenServicePoWDefensesEnabled 1
+HiddenServicePoWQueueRate 250
+HiddenServicePoWQueueBurst 2500
+
+## 3. Stream (connection) limits per rendezvous circuit
+HiddenServiceMaxStreams 200
+HiddenServiceMaxStreamsCloseCircuit 1
+
+## 4. Circuit-ID export for nginx per-circuit rate limiting
+HiddenServiceExportCircuitID haproxy
+
+## 5. Number of introduction points
+HiddenServiceNumIntroductionPoints 3


### PR DESCRIPTION
## Problem

No intro-point rate limiting, no PoW, no stream limits at the Tor level.
The nginx limit_req_zone $binary_remote_addr was completely ineffective for onion traffic — every Tor circuit arrives from 127.0.0.1, so all clients (and all attackers) shared a single rate-limit bucket.
/ws/, /relay, /nostr, and /blossom/ had no rate limits at all.
No connection timeouts; slow-loris style connections could hold workers indefinitely.

## Retionale

https://github.com/RoboSats/robosats-deploy/pull/43/changes#diff-9be742552e81ba778e7bb8c4aa3bfce36dff843e66a726d2c2aaa75565e25ace

## Solution
Layer 1 — Intro-point rate limiting (torrc)
HiddenServiceEnableIntroDoSDefense 1 — limits introduction requests at the Tor relay before they reach the coordinator machine.

Layer 2 — Proof-of-Work client puzzle (torrc)
HiddenServicePoWDefensesEnabled 1 — clients must solve a CPU puzzle (Equi-X/HashX, auto-tuned to zero effort when idle, increasing under attack). Requires tor ≥ 0.4.8.1 with --enable-gpl. The Tor Docker image is pinned to Alpine 3.21 and the build now hard-fails if pow: yes is not present.

Layer 3 — Stream limits + Circuit-ID export (torrc)
HiddenServiceMaxStreams 200 + HiddenServiceMaxStreamsCloseCircuit 1 tears down abusive circuits.
HiddenServiceExportCircuitID haproxy makes Tor prepend a PROXY-protocol header encoding a unique circuit pseudo-IP, which nginx uses for true per-circuit rate limiting (port 81 vhost).

Layer 4 — nginx per-circuit rate limiting + caching (nginx conf)

New listen 127.0.0.1:81 proxy_protocol vhost keyed on $proxy_protocol_addr (circuit pseudo-IP) instead of the useless 127.0.0.1.
Per-circuit limit_req / limit_conn zones for all endpoints; stricter zones for /ws/, /relay, /blossom/, /coordinator.
5-second proxy_cache for /api/info|limits|ticks|book — a single upstream request fires per cache miss under a flood.
Connection timeouts (client_body_timeout, client_header_timeout, send_timeout, reset_timedout_connection), return 444 for empty User-Agent.
Clearnet vhost on port 80 is untouched.
MetricsPort 127.0.0.1:9035 is added to all torrc samples for monitoring tor_hs_pow_suggested_effort and tor_hs_rdv_pow_pqueue_count.

Private admin onions (admin panel, Thunderhub, LiT, LNDg) get intro-DoS + stream limits only — no PoW burden for operators.

## Testing

docker run --rm --entrypoint /usr/bin/tor robosats-tor --list-modules → pow: yes ✅
docker run --rm -v $PWD/compose/nginx/tn.conf.d:/etc/nginx/conf.d:ro nginx:alpine nginx -t → syntax OK ✅