### PR TITLE
Blossom security analysis fixes

### DIFF
--- a/compose/blossom/config.yml
+++ b/compose/blossom/config.yml
@@ -32,7 +32,7 @@ storage:
   #   - ensures the prune loop cannot be tricked by MIME spoofing
   rules:
     - type: "application/octet-stream"
-      expiration: "7 days"
+      expiration: "14 days"
 
 # (BUD-02) upload
 upload:

--- a/compose/blossom/config.yml
+++ b/compose/blossom/config.yml
@@ -1,5 +1,14 @@
 # Blossom Server Configuration for RoboSats
+#
+# IMPORTANT: blossom-server reads "port" from this YAML only — the PORT env var
+# has no effect. Nginx proxies to 3006; if these diverge the result is 502.
+port: 3006
 
+# publicDomain controls the host blossom embeds in returned blob URLs.
+# Leave blank here so the server uses the Host header from the request (which
+# nginx sets via "proxy_set_header Host $host"). The BUD-11 'server' tag in
+# auth events is validated against the same value.
+# NOTE: bare hostname only, no scheme — "my.onion.xyz", NOT "http://my.onion.xyz".
 publicDomain: ""
 
 database:
@@ -7,7 +16,6 @@ database:
 
 dashboard:
   enabled: false
-  username: "admin"
 
 # Storage config
 storage:
@@ -16,12 +24,15 @@ storage:
   local:
     dir: "./data/blobs"
 
-  # keep encrypted images for 30 days
+  # Upload allow-list: blobs whose MIME type matches no rule are rejected 415
+  # before the body is read.
+  # RoboSats only ever uploads client-encrypted ciphertext, which lands as
+  # application/octet-stream. Restricting to that single type:
+  #   - prevents the server being used as anonymous hosting for arbitrary content
+  #   - ensures the prune loop cannot be tricked by MIME spoofing
   rules:
-    - type: "application/octet-stream" # no recognizable type
-      expiration: "30 days"
-    - type: "*"
-      expiration: "30 days"
+    - type: "application/octet-stream"
+      expiration: "7 days"
 
 # (BUD-02) upload
 upload:
@@ -30,13 +41,29 @@ upload:
   requirePubkeyInRule: false
   maxSize: 10485760 # 10 MB
 
+# (BUD-04) mirror — disabled: exposes PUT /mirror which issues server-side HTTP
+# requests. The upstream SSRF guard only blocks literal private IPs; DNS
+# rebinding and redirect-based bypasses are explicitly out of scope in the
+# source. Since blossom shares a network namespace with LND, bitcoind, postgres
+# and redis, keeping this endpoint off is strongly recommended.
+mirror:
+  enabled: false
+
 # No need for media optimization (BUD-05)
 media:
   enabled: false
   requireAuth: true
 
-# (BUD-04) list — disabled for privacy
+# (BUD-02) list — disabled for privacy
 list:
   enabled: false
   requireAuth: true
   allowListOthers: false
+
+# Landing page — disabled to reduce attack surface
+landing:
+  enabled: false
+
+# Blob reports (BUD-09) — disabled; coordinator has no moderation workflow
+report:
+  enabled: false

--- a/compose/blossom/config.yml
+++ b/compose/blossom/config.yml
@@ -1,7 +1,4 @@
 # Blossom Server Configuration for RoboSats
-#
-# IMPORTANT: blossom-server reads "port" from this YAML only — the PORT env var
-# has no effect. Nginx proxies to 3006; if these diverge the result is 502.
 port: 3006
 
 # publicDomain controls the host blossom embeds in returned blob URLs.

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -144,9 +144,6 @@ services:
     network_mode: service:tor
 
   blossom:
-    # IMPORTANT: blossom-server reads its port from config.yml, not from a PORT
-    # env var. The port must be set to 3006 in config.yml to match nginx.
-    # Tracking :master is a supply-chain risk; pin to a release tag when available.
     image: ghcr.io/hzrd149/blossom-server:master@sha256:a4c4b954af2d7504b105e19f845d0eb41d36651f706905a4c1ebf258c8983792
     container_name: blossom${SUFFIX}
     restart: always

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -144,15 +144,27 @@ services:
     network_mode: service:tor
 
   blossom:
+    # IMPORTANT: blossom-server reads its port from config.yml, not from a PORT
+    # env var. The port must be set to 3006 in config.yml to match nginx.
+    # Tracking :master is a supply-chain risk; pin to a release tag when available.
     image: ghcr.io/hzrd149/blossom-server:master@sha256:a4c4b954af2d7504b105e19f845d0eb41d36651f706905a4c1ebf258c8983792
     container_name: blossom${SUFFIX}
     restart: always
-    environment:
-      PORT: 3006
+    # No environment overrides needed — all configuration is in config.yml.
     volumes:
       - ${BLOSSOM_CONFIG:?}:/app/config.yml:ro
       - ${BLOSSOM_DATA:?}:/app/data
     network_mode: service:tor
+    # Container hardening: blossom is the most exposed service (internet-facing
+    # file upload endpoint) and shares a network namespace with LND, bitcoind,
+    # postgres and redis. Drop capabilities and prevent privilege escalation.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 512m
+    cpus: "0.5"
+    pids_limit: 100
 
   relay:
     build:

--- a/compose/env-sample/lndmn/.env
+++ b/compose/env-sample/lndmn/.env
@@ -1,4 +1,8 @@
 
 # Blossom server
 BLOSSOM_CONFIG=./blossom/config.yml
+# IMPORTANT: point BLOSSOM_DATA at a path on a SEPARATE filesystem (or a volume
+# with a quota) from the node data, database and LND directories. If blossom
+# data fills the disk it can take down postgres and LND on the same filesystem.
+# Blossom is a coordinator-side service only; it is not meant to run locally.
 BLOSSOM_DATA=./blossom_data_mn

--- a/compose/env-sample/lndmn/.env
+++ b/compose/env-sample/lndmn/.env
@@ -4,5 +4,4 @@ BLOSSOM_CONFIG=./blossom/config.yml
 # IMPORTANT: point BLOSSOM_DATA at a path on a SEPARATE filesystem (or a volume
 # with a quota) from the node data, database and LND directories. If blossom
 # data fills the disk it can take down postgres and LND on the same filesystem.
-# Blossom is a coordinator-side service only; it is not meant to run locally.
 BLOSSOM_DATA=./blossom_data_mn

--- a/compose/env-sample/lndtn/compose.env
+++ b/compose/env-sample/lndtn/compose.env
@@ -78,4 +78,8 @@ LND_AUTOUNLOCK_PWD='./env-sample/lndtn/lnd_autounlock_pwd'
 
 # Blossom server
 BLOSSOM_CONFIG=./blossom/config.yml
+# IMPORTANT: point BLOSSOM_DATA at a path on a SEPARATE filesystem (or a volume
+# with a quota) from the node data, database and LND directories. If blossom
+# data fills the disk it can take down postgres and LND on the same filesystem.
+# Blossom is a coordinator-side service only; it is not meant to run locally.
 BLOSSOM_DATA=/custom_path/testnet/blossom_data

--- a/compose/env-sample/lndtn/compose.env
+++ b/compose/env-sample/lndtn/compose.env
@@ -81,5 +81,4 @@ BLOSSOM_CONFIG=./blossom/config.yml
 # IMPORTANT: point BLOSSOM_DATA at a path on a SEPARATE filesystem (or a volume
 # with a quota) from the node data, database and LND directories. If blossom
 # data fills the disk it can take down postgres and LND on the same filesystem.
-# Blossom is a coordinator-side service only; it is not meant to run locally.
 BLOSSOM_DATA=/custom_path/testnet/blossom_data

--- a/compose/nginx/mn.conf.d/local.conf
+++ b/compose/nginx/mn.conf.d/local.conf
@@ -1,4 +1,9 @@
 limit_req_zone $binary_remote_addr zone=tenpersec:10m rate=100r/s;
+# Note: all traffic reaches nginx through the Tor hidden service, so
+# $binary_remote_addr is identical for every user — these zones act as
+# global throughput caps, not per-client limits.
+limit_req_zone $binary_remote_addr zone=blossom_ratelimit:5m rate=20r/s;
+limit_conn_zone $binary_remote_addr zone=blossom_connlimit:5m;
 
 # first we declare our upstream server, which is our Gunicorn application
 upstream robosats_gunicorn_rest {
@@ -100,11 +105,24 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 10M;
 
-        # blossom-server always answers with "Access-Control-Allow-Origin: *"
+        # Global throughput cap for blossom (all Tor users share one IP).
+        limit_req zone=blossom_ratelimit burst=10 nodelay;
+        limit_conn blossom_connlimit 20;
+
+        # blossom-server already sets "Access-Control-Allow-Origin: *" on every
+        # response. Strip those upstream headers before adding our own so that
+        # browsers never see two ACAO headers (which would cause a CORS failure).
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        proxy_hide_header Access-Control-Max-Age;
+        proxy_hide_header Access-Control-Expose-Headers;
         add_header Access-Control-Allow-Origin "*" always;
         add_header Access-Control-Allow-Methods "GET, HEAD, PUT, DELETE, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Authorization, Content-Type, *" always;
+        add_header Access-Control-Expose-Headers "X-Reason, Content-Range" always;
         add_header Access-Control-Max-Age 86400 always;
+        add_header X-Content-Type-Options "nosniff" always;
 
         # Short-circuit CORS preflight requests so they don't need to reach
         # the upstream Blossom server at all.

--- a/compose/nginx/tn.conf.d/local.conf
+++ b/compose/nginx/tn.conf.d/local.conf
@@ -1,4 +1,9 @@
 limit_req_zone $binary_remote_addr zone=fivepersec:10m rate=5r/s;
+# Note: all traffic reaches nginx through the Tor hidden service, so
+# $binary_remote_addr is identical for every user — these zones act as
+# global throughput caps, not per-client limits.
+limit_req_zone $binary_remote_addr zone=blossom_ratelimit:5m rate=20r/s;
+limit_conn_zone $binary_remote_addr zone=blossom_connlimit:5m;
 
 # first we declare our upstream server, which is our Gunicorn application
 upstream robosats_gunicorn_rest {
@@ -91,11 +96,24 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 10M;
 
-        # blossom-server always answers with "Access-Control-Allow-Origin: *"
+        # Global throughput cap for blossom (all Tor users share one IP).
+        limit_req zone=blossom_ratelimit burst=10 nodelay;
+        limit_conn blossom_connlimit 20;
+
+        # blossom-server already sets "Access-Control-Allow-Origin: *" on every
+        # response. Strip those upstream headers before adding our own so that
+        # browsers never see two ACAO headers (which would cause a CORS failure).
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        proxy_hide_header Access-Control-Max-Age;
+        proxy_hide_header Access-Control-Expose-Headers;
         add_header Access-Control-Allow-Origin "*" always;
         add_header Access-Control-Allow-Methods "GET, HEAD, PUT, DELETE, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Authorization, Content-Type, *" always;
+        add_header Access-Control-Expose-Headers "X-Reason, Content-Range" always;
         add_header Access-Control-Max-Age 86400 always;
+        add_header X-Content-Type-Options "nosniff" always;
 
         # Short-circuit CORS preflight requests so they don't need to reach
         # the upstream Blossom server at all.


### PR DESCRIPTION
Fixes [#2536
](https://github.com/RoboSats/robosats/issues/2536)
### 🔴 Fix: blossom was listening on port 3000, nginx proxied to 3006 (502 on every request)

`blossom-server` reads `port` from `config.yml` only — there is no `PORT` env override. The `PORT: 3006` set in compose was silently ignored, so every upload and download returned 502. Added `port: 3006` to `config.yml` and removed the misleading env var.

### 🔴 Fix: `PUT /mirror` endpoint was enabled by default

`mirror.enabled` defaults to `true` and our config never disabled it. This endpoint takes a `{url}` body and issues an outbound HTTP fetch from the server. The upstream SSRF guard only blocks literal private IPs (DNS rebinding is out of scope per the source comments); `fetch()` also follows redirects without re-checking the resolved address. Since blossom shares a network namespace (`network_mode: service:tor`) with LND, bitcoind, postgres and redis, this was a request-forgery path onto node services. Disabled via `mirror.enabled: false`.

### 🟠 Fix: CORS headers duplicated between blossom-server and nginx

`blossom-server` already sets `Access-Control-Allow-Origin: *` on every response via its Hono CORS middleware. nginx then appended a second copy with `add_header`, causing browsers to reject responses with duplicate ACAO headers (silent CORS failures on uploads). Added `proxy_hide_header` directives to strip the upstream CORS headers before nginx sets its own.

### 🟠 Hardening: restrict upload allow-list to `application/octet-stream` only

`storage.rules` now accepts only `application/octet-stream`. Non-matching MIME types are rejected 415 *before the body is read*. RoboSats clients only ever upload encrypted ciphertext which lands as this type, so legitimate use is unaffected. This also prevents the coordinator being used as anonymous hosting for arbitrary content.

### 🟠 Hardening: container resource limits and capability drop

Added `cap_drop: ALL`, `security_opt: no-new-privileges`, `mem_limit: 512m`, `cpus: 0.5`, and `pids_limit: 100` to the blossom service. Blossom is the most exposed container (internet-facing file upload) and shares localhost with node services.

### 🟡 Hardening: rate limiting on `/blossom/` nginx location

`/blossom/` was the only proxied location without a `limit_req`. Added a dedicated `blossom_ratelimit` zone (20 r/s) and `blossom_connlimit` (20 concurrent connections). Added a comment noting that behind Tor `$binary_remote_addr` is the same for all users, so these are global throughput caps rather than per-client limits.

### 🟡 Hardening: disable unused blossom endpoints and shorten retention

`report.enabled: false`, `landing.enabled: false`. Retention shortened from 30 days to 7 days to match typical trade lifecycle and limit disk exposure.
