### PR TITLE
Fix static files setup for fresh coordinator

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -114,7 +114,8 @@ tn-manage createsuperuser # `tn-manage` is the alias for `docker exec -it rs-lnd
 ```
 docker compose -p lndtest --env-file env/stack-lndtn.env build
 docker compose -p lndtest --env-file env/stack-lndtn.env up -d
-docker exec -it rs-lndtn cp -R frontend/static/frontend /usr/src/static
+docker exec -it rs-lndtn cp -R frontend/static/. /usr/src/static/
+docker exec -it rs-lndtn cp -R /usr/local/lib/python3.12/site-packages/django/contrib/admin/static/admin /usr/src/static/
 docker exec -it rs-lndtn python3 manage.py createsuperuser
 docker compose -p lndtest --env-file env/stack-lndtn.env restart
 ```


### PR DESCRIPTION
Fixes two issues found while testing a fresh coordinator deployment:

- Copy all frontend static files into `/usr/src/static/` instead of only the `frontend` directory.
- Copy Django admin static files so the `/coordinator` interface loads its CSS and JS correctly.

Both changes were tested on a clean coordinator deployment.